### PR TITLE
Use array Q code when available, if necessary (non-LP64 system)

### DIFF
--- a/core.py
+++ b/core.py
@@ -8,10 +8,18 @@ import array
 import sys
 import math
 
-VERSION_STR = "0.1"
+VERSION_STR = "0.2"
 
-# array.array codes to use with given bitwidths/8
-arrayTypes = ('B', 'H', 'I', 'I', 'L', 'L', 'L', 'L')
+# array.array codes to use with given bitwidths/8. Assume LP64 system first
+arrayTypes = "BHIILLLL"
+if array.array('L').itemsize != 8:
+    # not LP64. since 3.3+ onwards, typecode "Q" exists for 64-bit, so switch to
+    # that if it's present. For 3.2-, out of luck really with array.array on
+    # this system, 32-bit wide integers is the max without numpy
+    if "typecodes" in dir(array) and "Q" in array.typecodes:
+        arrayTypes = arrayTypes.replace("L", "Q")
+    else:
+        print("WARNING: Numeric range restricted to 32-bits!", file=sys.stderr)
 
 if sys.version < '3':
     integerTypes = (int, long)

--- a/reader.py
+++ b/reader.py
@@ -338,8 +338,9 @@ def parseIntoBinaryTracks(stream, chNames, timebase):
     # but also store the inital values for later, when we create channels
     chInitials = icomps[1:]
 
-    # use list comprehension to make a tuple of empty lists
-    chData = tuple( [ array.array('L') for _ in xrange(channelCount)] )
+    # use list comprehension to make a tuple of empty lists, attempt to get 64
+    # bits (won't work on non LP64 systems with <3.3 python)
+    chData = tuple( [ core.makeUnsignedList(64) for _ in xrange(channelCount)] )
 
     # we need to access this to final closing to the channels
     ts = None


### PR DESCRIPTION
On systems where `sizeof(int) != sizeof(long)` in 64-bit mode, using the `'L'` typecode will yield 32-bit integers, which is not enough to be useful for binary delta decoding (nor representation really). For 3.3+ python, use typecode `'Q'` (fixes the issue on such systems), and on older, detect the issue and emit stderr warning about it. Can't do much without replacing `array.array` with something else (and adding external project dependencies).

Also bump version in preparation for release 0.2