### PR TITLE
Add segmentPicker

### DIFF
--- a/core.py
+++ b/core.py
@@ -201,7 +201,7 @@ class UnsignedTrack(Track):
 
     # Storage mechanism is application of value, then waiting for delta (ie,
     # same order as iterator)
-    def __init__(self, name, timebase, bitwidth, duration=None):
+    def __init__(self, name, timebase, bitwidth, duration=None, fromSegiter=None):
         Track.__init__(self, name, timebase, duration)
         self.width = bitwidth
         self.delta = makeUnsignedList(64)
@@ -211,6 +211,8 @@ class UnsignedTrack(Track):
         self.hiZValue = None
         # default to bit-vector emitting
         self.setVCDTypeToReal(False)
+        if fromSegiter != None:
+            self.setSegments(fromSegiter)
 
     # helper to split the deltas and values from a combiner set. note that combiner
     # should return (delta, value), not (delta, value1, value2, ...)
@@ -315,7 +317,7 @@ class UnsignedTrack(Track):
 #  value at start of specific delta at given index: initialValue ^ ((deltaIdx+1) % 2)
 class BinaryTrack(Track):
 
-    def __init__(self, name, timebase, initial=0, data=None, duration=None):
+    def __init__(self, name, timebase, initial=0, data=None, duration=None, fromSegiter=None):
         Track.__init__(self, name, timebase, duration)
         self.initial = initial
         self.data = data
@@ -329,6 +331,8 @@ class BinaryTrack(Track):
             #       we end with a flip just at the end, and the next section
             #       duration is zero
             self.duration = sum(self.data)+1
+        if fromSegiter != None:
+            self.setSegments(fromSegiter)
 
     def __repr__(self):
         return "<%s, i=%u, transitions=%u>" % (


### PR DESCRIPTION
Selects or unselects segments from input individually, using a second iterator where a change (any) is the selector input. Emitted segment values can be overridden based on select/unselect (or retained) and selection inverted.

Useful when picking mode related segments based on an auxiliary change signal for futher processing or modification of mode.

BinaryTrack and UnsignedTrack now also support `fromSegiter` keyword parameter in constructor, so that a new track can be created based on existing segiter data in one operation.