### PR TITLE
Add addSyntheticTransitions and allow replacer to run without a filter

### DIFF
--- a/core.py
+++ b/core.py
@@ -578,8 +578,13 @@ def getBasicStatistics(comb):
 #   otherwise replaceFunc should return an iterable with at least one segment
 #   which the same configuration as the original data. iterator may return
 #   multiple segments as well, and all will be returned to caller
+# If filterFunc is None, no filtering will be done (replaceFunc will be called
+# on each segment)
 # NOTE: returned segments might be unclean
 def replacer(segiter, filterFunc, replaceFunc):
+    if filterFunc is None:
+        # function that return True irrespective of number of positional variables
+        filterFunc = lambda *_: True
     for segment in segiter:
         if not filterFunc(*segment):
             # filter didn't match, pass as is


### PR DESCRIPTION
`addSyntheticTransitions` is a higher level utility to split a segment with given value into two or three segments representing synthetic intermediate modes going into and coming out of a single "mode".

This is mainly useful when modeling transitions from ON -> OFF and OFF -> ON where we know that each transition actually needs to go through additional POWERDOWN and POWERUP modes (each with separate timings).

Additionally, `replacer` can be used with a `None` as filter, meaning that replacer will run unfiltered (will process each input segment)