### PR TITLE
maintenance: remove six.py (unneeded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ it will be documented with examples, but for now, source is it.
 
 # LICENSE
 
-Scorpy is distributed under the GPLv2 license, except for the bundled "six"
-helper library whose license is contained in the source file preamble and the
-median calculation helper in statistics.py whose license is unknown (see source)
+Scorpy is distributed under the GPLv2 license, except for the median calculation
+helper in statistics.py whose license is unknown (see source)
 
 # Scorpy library source code
 
@@ -19,10 +18,9 @@ Contains the core classes and generators
 
 Contains support code to read capture data from various file formats
 
-## six
+## report
 
-In-line copy of six, should be probably removed anyways since not that useful
-anymore.
+Contains reuseable higher level report functions (one ore more)
 
 ## statistics
 

--- a/reader.py
+++ b/reader.py
@@ -10,13 +10,20 @@
 # SPDX-License-Identifier: GPL-2.0
 
 from __future__ import print_function
-from scorpy.six.moves import cPickle as pickle
-from scorpy.six.moves import xrange
 import sys
 import os.path
 import re
 import struct
 import array
+
+# we use xrange internally here, and xPickle. No need to use depend on six.py
+# for these.
+if sys.version_info[0] >= 3:
+  import pickle
+  xrange = range
+else:
+  # python < 3
+  import cPickle as pickle
 
 from scorpy import core
 


### PR DESCRIPTION
Functionality that six was used for was replaced by internal short renames in reader.py (only place which needed six previously)